### PR TITLE
fix: crash with create 0.5.1-i (1.18.2)

### DIFF
--- a/src/main/java/snownee/jade/addon/mixin/create/GoggleOverlayRendererMixin.java
+++ b/src/main/java/snownee/jade/addon/mixin/create/GoggleOverlayRendererMixin.java
@@ -5,8 +5,6 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
-import com.mojang.blaze3d.platform.Window;
-import com.mojang.blaze3d.vertex.PoseStack;
 import com.simibubi.create.content.equipment.goggles.GoggleOverlayRenderer;
 
 import snownee.jade.addon.create.CreatePlugin;
@@ -15,7 +13,7 @@ import snownee.jade.api.config.IWailaConfig;
 @Mixin(value = GoggleOverlayRenderer.class, remap = false)
 public class GoggleOverlayRendererMixin {
 	@Inject(at = @At("HEAD"), method = "renderOverlay", cancellable = true)
-	private static void jadeaddons$renderOverlay(PoseStack poseStack, float partialTicks, Window window, CallbackInfo ci) {
+	private static void jadeaddons$renderOverlay(CallbackInfo ci) {
 		if (IWailaConfig.get().getPlugin().get(CreatePlugin.GOGGLES)) {
 			ci.cancel();
 		}


### PR DESCRIPTION
Jade Addons crashes when paired with [Create 0.5.1-i](https://modrinth.com/mod/create-fabric/version/0.5.1-i-build.1598+mc1.18.2) on Minecraft 1.18.2 during world loading. This issue occurs because the `renderOverlay` method in the `GoggleOverlayRenderer` class of Create, which is targeted by a Jade Addons mixin, had its method signature changed in Create version 0.5.1-i. This fix adjusts the mixin to remove unnecessary parameters, restoring compatibility with the updated method signature. The change should remain compatible with previous versions of Create as well.