### PR TITLE
fix: potential crash with create (1.21)

### DIFF
--- a/src/legacy/java/snownee/jade/addon/mixin/create/GoggleOverlayRendererMixin.java
+++ b/src/legacy/java/snownee/jade/addon/mixin/create/GoggleOverlayRendererMixin.java
@@ -5,17 +5,15 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
-import com.mojang.blaze3d.platform.Window;
 import com.simibubi.create.content.equipment.goggles.GoggleOverlayRenderer;
 
-import net.minecraft.client.gui.GuiGraphics;
 import snownee.jade.addon.create.CreatePlugin;
 import snownee.jade.api.config.IWailaConfig;
 
 @Mixin(value = GoggleOverlayRenderer.class, remap = false)
 public class GoggleOverlayRendererMixin {
 	@Inject(at = @At("HEAD"), method = "renderOverlay", cancellable = true)
-	private static void jadeaddons$renderOverlay(GuiGraphics guiGraphics, float partialTicks, Window window, CallbackInfo ci) {
+	private static void jadeaddons$renderOverlay(CallbackInfo ci) {
 		if (IWailaConfig.get().getPlugin().get(CreatePlugin.GOGGLES)) {
 			ci.cancel();
 		}


### PR DESCRIPTION
Jade Addons crashes during world loading when paired with the latest versions of Create on Minecraft 1.20.1, 1.19.2, and 1.18.2. This occurs because the `renderOverlay` method in the `GoggleOverlayRenderer` class of Create, which is targeted by a mixin in Jade Addons, has had its method signature changed in recent Create updates. Although Create has not yet released for Minecraft 1.21, the same issue is likely to occur when Create becomes available for that version. This pull request preemptively applies the same fix implemented for Minecraft 1.20.1, ensuring that Jade Addons remains compatible with Create when it is released for Minecraft 1.21.